### PR TITLE
Implemented Mana repair for Botania items

### DIFF
--- a/src/main/java/com/brightspark/sparkshammers/init/SHItemsBotania.java
+++ b/src/main/java/com/brightspark/sparkshammers/init/SHItemsBotania.java
@@ -1,0 +1,40 @@
+package com.brightspark.sparkshammers.init;
+
+import com.brightspark.sparkshammers.item.ItemHammerMana;
+import com.brightspark.sparkshammers.reference.Names;
+
+/**
+ * @author CreeperShift
+ * com.brightspark.sparkshammers.init
+ * Oct 15, 2016
+ */
+
+/**
+ * 
+ * Seperate class to register Botania tools because it now requires Botania to
+ * not crash. This way the ItemHammerMana class isn't loaded when Botania is not
+ * there
+ * 
+ */
+
+public class SHItemsBotania {
+
+	public static void registerManasteel() {
+
+		SHItems.regItem(SHModItems.hammerManasteel = new ItemHammerMana(Names.EnumMaterials.MANASTEEL));
+		SHItems.regItem(SHModItems.excavatorManasteel = new ItemHammerMana(Names.EnumMaterials.MANASTEEL, true));
+	}
+
+	public static void registerTerrasteel() {
+		SHItems.regItem(SHModItems.hammerTerrasteel = new ItemHammerMana(Names.EnumMaterials.TERRASTEEL));
+		SHItems.regItem(SHModItems.excavatorTerrasteel = new ItemHammerMana(Names.EnumMaterials.TERRASTEEL, true));
+
+	}
+
+	public static void registerElementium() {
+		SHItems.regItem(SHModItems.hammerElementium = new ItemHammerMana(Names.EnumMaterials.ELEMENTIUM));
+		SHItems.regItem(SHModItems.excavatorElementium = new ItemHammerMana(Names.EnumMaterials.ELEMENTIUM, true));
+
+	}
+
+}

--- a/src/main/java/com/brightspark/sparkshammers/init/SHModItems.java
+++ b/src/main/java/com/brightspark/sparkshammers/init/SHModItems.java
@@ -77,16 +77,13 @@ public class SHModItems
 
                     //Botania
                     case MANASTEEL:
-                        SHItems.regItem(hammerManasteel = new ItemAOE(Names.EnumMaterials.MANASTEEL));
-                        SHItems.regItem(excavatorManasteel = new ItemAOE(Names.EnumMaterials.MANASTEEL, true));
+                        SHItemsBotania.registerManasteel();
                         break;
                     case TERRASTEEL:
-                        SHItems.regItem(hammerTerrasteel = new ItemAOE(Names.EnumMaterials.TERRASTEEL));
-                        SHItems.regItem(excavatorTerrasteel = new ItemAOE(Names.EnumMaterials.TERRASTEEL, true));
+                    	SHItemsBotania.registerTerrasteel();
                         break;
                     case ELEMENTIUM:
-                        SHItems.regItem(hammerElementium = new ItemAOE(Names.EnumMaterials.ELEMENTIUM));
-                        SHItems.regItem(excavatorElementium = new ItemAOE(Names.EnumMaterials.ELEMENTIUM, true));
+                    	SHItemsBotania.registerElementium();
                         break;
 
                     //EnderIO

--- a/src/main/java/com/brightspark/sparkshammers/item/ItemHammerMana.java
+++ b/src/main/java/com/brightspark/sparkshammers/item/ItemHammerMana.java
@@ -1,0 +1,96 @@
+package com.brightspark.sparkshammers.item;
+
+import com.brightspark.sparkshammers.reference.Names.EnumMaterials;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import vazkii.botania.api.mana.IManaUsingItem;
+import vazkii.botania.api.mana.ManaItemHandler;
+
+/**
+ * @author CreeperShift
+ * com.brightspark.sparkshammers.item
+ * Oct 15, 2016
+ */
+
+public class ItemHammerMana extends ItemAOE implements IManaUsingItem {
+
+	private static int damageToMana = 60; // This is the default value for
+											// Terrasteel 1 Damage --> Mana
+											// ratio
+
+	public ItemHammerMana(EnumMaterials manasteel) {
+		super(manasteel);
+	}
+
+	public ItemHammerMana(EnumMaterials manasteel, boolean isExcavator) {
+		super(manasteel, isExcavator);
+	}
+
+	/**
+	 * Calaculate mana cost and request it. If not enough, we damage the tool
+	 * normally.
+	 */
+
+	public static void damageItem(ItemStack stack, int dmg, EntityLivingBase entity) {
+
+		int manaToRequest = dmg * damageToMana;
+		boolean manaRequested = entity instanceof EntityPlayer
+				? ManaItemHandler.requestManaExactForTool(stack, (EntityPlayer) entity, manaToRequest, true) : false;
+
+		if (!manaRequested) {
+			stack.damageItem(dmg, entity);
+		}
+	}
+
+	/**
+	 * Item uses Mana, so we display the Mana bar
+	 */
+	@Override
+	public boolean usesMana(ItemStack arg0) {
+		return true;
+	}
+
+	/**
+	 * 
+	 * If we have a mana providing item such as a mana tablet available, do not
+	 * damage the tool
+	 */
+
+	@Override
+	public boolean hitEntity(ItemStack stack, EntityLivingBase entityHit, EntityLivingBase player) {
+
+		damageItem(stack, 1, player);
+		return true;
+	}
+
+	@Override
+	public boolean onBlockDestroyed(ItemStack stack, World world, IBlockState state, BlockPos pos,
+			EntityLivingBase player) {
+		if (state.getBlockHardness(world, pos) != 0F) {
+
+			damageItem(stack, 1, player);
+
+		}
+		return true;
+	}
+
+	/**
+	 * 
+	 * Handle Hammer/Excavator repair Null checks, check if we have enough mana
+	 * Uses default Botania values (double the mana ratio)
+	 */
+
+	@Override
+	public void onUpdate(ItemStack stack, World worldIn, Entity entityIn, int itemSlot, boolean isSelected) {
+
+		if (!worldIn.isRemote && entityIn instanceof EntityPlayer && stack.getItemDamage() > 0
+				&& ManaItemHandler.requestManaExactForTool(stack, (EntityPlayer) entityIn, damageToMana * 2, true))
+			stack.setItemDamage(stack.getItemDamage() - 1);
+	}
+
+}


### PR DESCRIPTION
Mana tools do no longer lose durability while a mana providing item is equipped, similar to regular mana tools. (Manasteel, Elementium, Terrasteel)

Mana tools can also be repaired after they have been damaged with mana, requireing 2x the mana, all exactly how botania mana tools work.

Also moved mana tool init into it's own file to avoid a crash that is caused by importing non existing Botania methods when the mod is used without Botania.

Requires a 1.10.2 deobfuscated version of Botania in the libs folder which can be downloaded here:
http://botaniamod.net/downloads.php
Sadly I did not find a maven repo for Botania.
