### PR TITLE
Add CraftTweaker Integration

### DIFF
--- a/src/main/java/brightspark/sparkshammers/SparksHammers.java
+++ b/src/main/java/brightspark/sparkshammers/SparksHammers.java
@@ -5,6 +5,7 @@ import brightspark.sparkshammers.hammerCrafting.HammerCraftingManager;
 import brightspark.sparkshammers.hammerCrafting.HammerShapedOreRecipe;
 import brightspark.sparkshammers.handlers.ConfigurationHandler;
 import brightspark.sparkshammers.init.*;
+import brightspark.sparkshammers.integration.crafttweaker.CraftTweakerIntegration;
 import brightspark.sparkshammers.item.ItemAOE;
 import brightspark.sparkshammers.reference.Config;
 import brightspark.sparkshammers.reference.Reference;
@@ -17,6 +18,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
@@ -59,6 +61,8 @@ public class SparksHammers
         //Initialize item, blocks, textures/models and configs here
 
         ConfigurationHandler.init(new File(Reference.CONFIG_DIR, "config.cfg"));
+        if(Loader.isModLoaded("crafttweaker"))
+        	CraftTweakerIntegration.init();
     }
 
     @Mod.EventHandler

--- a/src/main/java/brightspark/sparkshammers/hammerCrafting/HammerCraftingManager.java
+++ b/src/main/java/brightspark/sparkshammers/hammerCrafting/HammerCraftingManager.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 public class HammerCraftingManager
 {
-    private static IForgeRegistry<HammerShapedOreRecipe> REGISTRY;
+    public static IForgeRegistry<HammerShapedOreRecipe> REGISTRY;
 
     /**
      * Returns the static instance of this class

--- a/src/main/java/brightspark/sparkshammers/integration/crafttweaker/AddRemoveAction.java
+++ b/src/main/java/brightspark/sparkshammers/integration/crafttweaker/AddRemoveAction.java
@@ -1,0 +1,39 @@
+package brightspark.sparkshammers.integration.crafttweaker;
+
+import crafttweaker.IAction;
+
+abstract public class AddRemoveAction {
+
+	private final class Add implements IAction {
+		@Override
+		public void apply() {
+			add();
+		}
+
+		@Override
+		public String describe() {
+			return String.format("Adding %s recipe: %s", getRecipeType(), getDescription());
+		}
+	}
+
+	private final class Remove implements IAction {
+		@Override
+		public void apply() {
+			remove();
+		}
+		
+		@Override
+		public String describe() {
+			return String.format("Removing %s recipe: %s", getRecipeType(), getDescription());
+		}
+	}
+	
+	public final IAction action_add = new Add();
+	public final IAction action_remove = new Remove();
+	
+	abstract protected void add();
+	abstract protected void remove();
+	abstract public String getRecipeType();
+	abstract public String getDescription();
+
+}

--- a/src/main/java/brightspark/sparkshammers/integration/crafttweaker/CTHammerCraftingTableRecipes.java
+++ b/src/main/java/brightspark/sparkshammers/integration/crafttweaker/CTHammerCraftingTableRecipes.java
@@ -1,0 +1,120 @@
+package brightspark.sparkshammers.integration.crafttweaker;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import brightspark.sparkshammers.hammerCrafting.HammerCraftingManager;
+import brightspark.sparkshammers.hammerCrafting.HammerShapedOreRecipe;
+import brightspark.sparkshammers.init.SHRecipes;
+import brightspark.sparkshammers.reference.Reference;
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.minecraft.CraftTweakerMC;
+import crafttweaker.mc1120.CraftTweaker;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.registries.IForgeRegistry;
+import net.minecraftforge.registries.IForgeRegistryModifiable;
+import net.minecraftforge.registries.RegistryBuilder;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+@ZenClass("mods.sparkshammers.HammerCrafting")
+public class CTHammerCraftingTableRecipes {
+
+	public static class HammerCraftingAction extends AddRemoveAction {
+		
+		public HammerCraftingAction(ItemStack output, List<ItemStack> input) {
+			this.output = output;
+			this.input = input;
+		}
+		
+		ItemStack output;
+		
+		List<ItemStack> input;
+
+		/**
+		 * Adds a recipe.
+		 * Due to {@link net.minecraftforge.common.crafting.CraftingHelper} the ingredients
+		 * need to be parsed individually.
+		 */
+		@Override
+		protected void add() {
+			HammerCraftingManager.REGISTRY.register(new HammerShapedOreRecipe(output, 
+					"ABCDE", "FGHIJ", "KLMN ", 
+					'A', input.get(0),  'B', input.get(1),  'C', input.get(2),  'D', input.get(3), 'E', input.get(4),
+					'F', input.get(5),  'G', input.get(6),  'H', input.get(7),  'I', input.get(8), 'J', input.get(9),
+					'K', input.get(10), 'L', input.get(11), 'M', input.get(12), 'N', input.get(13)
+					));
+		}
+
+		
+		/**
+		 * Only looks up and removes a recipe based on the output
+		 */
+		@Override
+		protected void remove() {
+			HammerShapedOreRecipe wanted = null;
+			try {
+				wanted = HammerCraftingManager.getRecipes().stream().filter(recipe -> recipe.getRecipeOutput().isItemEqual(output)).findFirst().get();
+			}
+			catch (NoSuchElementException e){
+				CraftTweakerAPI.logError(String.format("Tried removing %s from %s but no recipe with matching output found.", getDescription(), getRecipeType()));
+			}
+			
+			if(wanted != null) {
+				//Fine to cast as it is allowing modifications
+				((IForgeRegistryModifiable)HammerCraftingManager.REGISTRY).remove(wanted.getRegistryName());
+			}
+		}
+
+		//Returns the type 
+		@Override
+		public String getRecipeType() {
+			return "HammerCraftingTable";
+		}
+
+		//Returns the output's display-name for CrT's log
+		@Override
+		public String getDescription() {
+			return output.getDisplayName();
+		}
+		
+	}
+	
+	@ZenMethod
+	static public void addRecipe(IItemStack _output, IItemStack[] _input) {
+		ItemStack output = null;
+		List<ItemStack> input = new ArrayList<ItemStack>();
+		try {
+			output = CraftTweakerMC.getItemStack(_output);
+			Arrays.asList(_input).forEach(iitemstack -> input.add(CraftTweakerMC.getItemStack(iitemstack)));
+		}
+		catch (IllegalArgumentException e){
+			CraftTweakerAPI.logError("Unable to add invalid HammerCraftingTable recipe: " + e.getMessage());
+		}
+		if(output != null && !input.isEmpty())
+			CraftTweakerAPI.apply(new HammerCraftingAction(output, input).action_add);
+	}
+	
+	@ZenMethod
+	static public void removeRecipe(IItemStack _output) {
+		ItemStack output = null;
+		try{
+			output = CraftTweakerMC.getItemStack(_output);
+		}
+		catch (IllegalArgumentException e) {
+			CraftTweakerAPI.logError("Unable to remove invalid HammerCraftingTable recipe: " + e.getMessage());
+		}
+		if(output != null)
+			CraftTweakerAPI.apply(new HammerCraftingAction(output, new ArrayList<ItemStack>()).action_remove);
+	}
+	
+}

--- a/src/main/java/brightspark/sparkshammers/integration/crafttweaker/CraftTweakerIntegration.java
+++ b/src/main/java/brightspark/sparkshammers/integration/crafttweaker/CraftTweakerIntegration.java
@@ -1,0 +1,12 @@
+package brightspark.sparkshammers.integration.crafttweaker;
+
+import crafttweaker.CraftTweakerAPI;
+import net.minecraftforge.fml.common.Optional;
+
+public class CraftTweakerIntegration {
+	
+	public static void init() {
+		CraftTweakerAPI.registerClass(CTHammerCraftingTableRecipes.class);
+	}
+
+}


### PR DESCRIPTION
Adds CraftTweaker Integration for the HammerCraftingTable:
Supports two methods: addRecipe(output, input...) & removeRecipe(output)
_Changes_ to base repo are loading CraftTweaker during preInit, and turning HammerCraftingManager#REGISTRY public.